### PR TITLE
Enable Streamable HTTP JSON response mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -874,6 +874,7 @@ async function main() {
     const createTransport = (sessionId = null) => {
         return new StreamableHTTPServerTransport({
             sessionIdGenerator: () => sessionId || crypto.randomBytes(16).toString('hex'),
+            enableJsonResponse: true,
             onsessioninitialized: (sessionId) => {
                 logWithTimestamp('INFO', `New MCP session initialized: ${sessionId}`);
             },


### PR DESCRIPTION
## Summary
- enable JSON response mode for Streamable HTTP transport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685277c1ab0883238322b37aa315e182